### PR TITLE
feat: add Doc Rio API key authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# python generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# venv
+.venv
+
+# TypeScript and CDK generated files
+*.tsbuildinfo
+/*.js
+/*.js.map
+/*.d.ts
+node_modules/
+dist/
+build/
+coverage/
+*.tgz
+*.log
+*.lock
+cdk.out/
+
+# Private TODOs
+SNS_TODO.md
+TODO.md
+
+# Exclude .js and .d.ts files in subdirectories
+*/**/*.js
+*/**/*.d.ts
+
+# AWS CDK files
+*.template.json
+
+# Local environment files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env
+data
+example.ipynb
+ignore_tests/

--- a/lambda/extraction/handler.py
+++ b/lambda/extraction/handler.py
@@ -17,6 +17,7 @@ DOC_RIO_API_URL = os.environ["DOC_RIO_API_URL"]
 DOC_RIO_AUTH_URL = os.environ["DOC_RIO_AUTH_URL"]
 DOC_RIO_CLIENT_ID = os.environ["DOC_RIO_CLIENT_ID"]
 DOC_RIO_CLIENT_SECRET = os.environ["DOC_RIO_CLIENT_SECRET"]
+DOC_RIO_API_KEY = os.environ["DOC_RIO_API_KEY"]
 
 IBM_APPCONNECT_URL = os.environ['IBM_APPCONNECT_URL']
 IBM_APPCONNECT_USERNAME = os.environ['IBM_APPCONNECT_USERNAME']
@@ -135,7 +136,8 @@ async def async_lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str,
         # Make API request to get SignedUrlV2
         headers = {
             'accept': 'application/json',
-            'Authorization': f'Bearer {bearer_token}'
+            'Authorization': f'Bearer {bearer_token}',
+            'x-api-key': DOC_RIO_API_KEY
         }
         params = {'Id': file_info_id}
         async with aiohttp.ClientSession() as session:

--- a/lib/lambda.ts
+++ b/lib/lambda.ts
@@ -37,6 +37,7 @@ export interface LambdaConstructProps {
         apiUrl: string;
         clientId: string;
         clientSecret: string;
+        apiKey: string;
     };
 }
 
@@ -77,6 +78,7 @@ export class LambdaConstruct extends Construct {
             DOC_RIO_API_URL: props.docRio.apiUrl,
             DOC_RIO_CLIENT_ID: props.docRio.clientId,
             DOC_RIO_CLIENT_SECRET: props.docRio.clientSecret,
+            DOC_RIO_API_KEY: props.docRio.apiKey,
             IBM_APPCONNECT_URL: props.ibmAppConnect.url,
             IBM_APPCONNECT_USERNAME: props.ibmAppConnect.username,
             IBM_APPCONNECT_PASSWORD: props.ibmAppConnect.password,

--- a/lib/sh-stack.ts
+++ b/lib/sh-stack.ts
@@ -51,6 +51,7 @@ export class SHStack extends cdk.Stack {
                     authUrl: process.env.DOC_RIO_AUTH_URL!,
                     clientId: process.env.DOC_RIO_CLIENT_ID!,
                     clientSecret: process.env.DOC_RIO_CLIENT_SECRET!,
+                    apiKey: process.env.DOC_RIO_API_KEY!,
                 },
             });
 


### PR DESCRIPTION
- Add DOC_RIO_API_KEY environment variable support
- Update Lambda handler to include API key in request headers
- Add infrastructure code for API key configuration
- Include SNS notification documentation for future implementation

This change enhances security by adding API key authentication to Doc Rio requests.